### PR TITLE
Add ability to ping tracker to indicate the server is online and offline.

### DIFF
--- a/olproxy/AppSettings.cs
+++ b/olproxy/AppSettings.cs
@@ -1,6 +1,7 @@
 ﻿namespace olproxy {
     public class AppSettings {
         public bool isServer { get; set; }
+        public bool signOff { get; set; }
         public string trackerBaseUrl { get; set; }
         public string serverName { get; set; }
         public string notes { get; set; }

--- a/olproxy/Program.cs
+++ b/olproxy/Program.cs
@@ -144,7 +144,7 @@ namespace olproxy
             };
 
             {
-                if (config.TryGetValue("isServer", out object isServer) && (bool)isServer && config.TryGetValue("signOff", out object signOff) && (bool)signOff) {
+                if (config.TryGetValue("isServer", out object isServer) && (bool)isServer) {
                     AddMessage("Signing on tracker at " + config["trackerBaseUrl"]);
 
                     http.PostAsync(config["trackerBaseUrl"] + "/api", new StringContent(MiniJson.ToString(new MJDict {


### PR DESCRIPTION
This adds a single online "ping" and offline "ping" to the tracker whenever isServer is true in appsettings.json.  Offline pings are also only sent when signOff is true in appsettings.json.