### PR TITLE
Remove tracker communication from olproxy

### DIFF
--- a/olproxy/AppSettings.cs
+++ b/olproxy/AppSettings.cs
@@ -1,9 +1,0 @@
-﻿namespace olproxy {
-    public class AppSettings {
-        public bool isServer { get; set; }
-        public bool signOff { get; set; }
-        public string trackerBaseUrl { get; set; }
-        public string serverName { get; set; }
-        public string notes { get; set; }
-    }
-}

--- a/olproxy/appsettings.json
+++ b/olproxy/appsettings.json
@@ -1,7 +1,0 @@
-{
-  "isServer": false,
-  "signOff": true,
-  "trackerBaseUrl": "https://olproxy.otl.gg",
-  "serverName": "An Overload Game Server",
-  "notes": "Change these notes to give information about your server, such as geographical location, hardware, bandwidth, etc."
-}

--- a/olproxy/olproxy.csproj
+++ b/olproxy/olproxy.csproj
@@ -23,10 +23,4 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 
-  <ItemGroup>
-    <None Update="appsettings.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Tracker communication moving from olproxy to olmod, since olproxy tracker support was flakey, and all we need with tracker 2.0 is a ping from the server anyway.